### PR TITLE
Fix bugs with localStorage and add removeItem/size public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ How It Works
 		// If the item doesn't exist it returns null.
 		cache.removeItem("A");
 
+		// Returns the number of items in the cache.
+		cache.size();
+
+		// Return stats about the cache, like {"hits": 1, "misses": 4}
+		cache.stats();
+
 		// clears all items from the cache
 		cache.clear();
 

--- a/cache.js
+++ b/cache.js
@@ -43,7 +43,6 @@ var CachePriority = {
 function Cache(maxSize, debug, storage) {
     this.maxSize_ = maxSize || -1;
     this.debug_ = debug || false;
-    this.count_ = 0;
     this.storage_ = storage || new Cache.BasicCacheStorage();
 
     this.fillFactor_ = .75;
@@ -60,15 +59,23 @@ function Cache(maxSize, debug, storage) {
  */
 Cache.BasicCacheStorage = function() {
   this.items_ = {};
+  this.count_ = 0;
 }
 Cache.BasicCacheStorage.prototype.get = function(key) {
   return this.items_[key];
 }
 Cache.BasicCacheStorage.prototype.set = function(key, value) {
+  if (typeof this.get(key) === "undefined")
+    this.count_++;
   this.items_[key] = value;
+}
+Cache.BasicCacheStorage.prototype.size = function(key, value) {
+  return this.count_;
 }
 Cache.BasicCacheStorage.prototype.remove = function(key) {
   var item = this.get(key);
+  if (typeof item !== "undefined")
+    this.count_--;
   delete this.items_[key];
   return item;
 }
@@ -105,6 +112,9 @@ Cache.LocalStorageCacheStorage.prototype.get = function(key) {
 }
 Cache.LocalStorageCacheStorage.prototype.set = function(key, value) {
   localStorage[this.prefix_ + key] = JSON.stringify(value);
+}
+Cache.LocalStorageCacheStorage.prototype.size = function(key, value) {
+  return this.keys().length;
 }
 Cache.LocalStorageCacheStorage.prototype.remove = function(key) {
   var item = this.get(key);
@@ -202,7 +212,7 @@ Cache.prototype.setItem = function(key, value, options) {
   this.log_("Setting key " + key);
 
   // if the cache is full, purge it
-  if ((this.maxSize_ > 0) && (this.count_ > this.maxSize_)) {
+  if ((this.maxSize_ > 0) && (this.size() > this.maxSize_)) {
     var that = this;
     setTimeout(function() {
       that.purge_.call(that);
@@ -236,7 +246,7 @@ Cache.prototype.getStats = function() {
  * @return {string} Returns an HTML string representation of the cache.
  */
 Cache.prototype.toHtmlString = function() {
-  var returnStr = this.count_ + " item(s) in cache<br /><ul>";
+  var returnStr = this.size() + " item(s) in cache<br /><ul>";
   var keys = this.storage_.keys()
   for (var i = 0; i < keys.length; i++) {
     var item = this.storage_.get(keys[i]);
@@ -259,7 +269,7 @@ Cache.prototype.resize = function(newMaxSize) {
   this.maxSize_ = newMaxSize;
 
   if (newMaxSize > 0 && (oldMaxSize < 0 || newMaxSize < oldMaxSize)) {
-    if (this.count_ > newMaxSize) {
+    if (this.size() > newMaxSize) {
       // Cache needs to be purged as it does contain too much entries for the new size
       this.purge_();
     } // else if cache isn't filled up to the new limit nothing is to do
@@ -275,7 +285,7 @@ Cache.prototype.purge_ = function() {
   var tmparray = new Array();
   var purgeSize = Math.round(this.maxSize_ * this.fillFactor_);
   if (this.maxSize_ < 0)
-    purgeSize = this.count_ * this.fillFactor_;
+    purgeSize = this.size() * this.fillFactor_;
   // loop through the cache, expire items that should be expired
   // otherwise, add the item to an array
   var keys = this.storage_.keys();
@@ -316,7 +326,6 @@ Cache.prototype.purge_ = function() {
 Cache.prototype.addItem_ = function(item, attemptedAlready) {
   var cache = this;
   try {
-    this.count_++;
     this.storage_.set(item.key, item);
   } catch(err) {
     if (attemptedAlready) {
@@ -347,6 +356,10 @@ Cache.prototype.removeItem = function(key) {
   }
   return item ? item.value : null;
 };
+
+Cache.prototype.size = function() {
+  return this.storage_.size();
+}
 
 
 /**

--- a/test.js
+++ b/test.js
@@ -15,14 +15,16 @@ function testBasicCaching(done) {
   assertEqual(stats.hits, 1);
   assertEqual(stats.misses, 1);
   assertEqual(cache.toHtmlString(), "1 item(s) in cache<br /><ul><li>foo = bar</li></ul>");
-  assertEqual(cache.count_, 1);
+  assertEqual(cache.size(), 1);
 
 
   cache.setItem("foo2", "bar2");
+  assertEqual(cache.size(), 2);
   assertEqual(cache.removeItem("foo"), "bar");
+  assertEqual(cache.size(), 1);
   cache.clear();
   assertEqual(cache.getItem("foo"), null);
-  assertEqual(cache.count_, 0);
+  assertEqual(cache.size(), 0);
   done();
 }
 
@@ -73,14 +75,14 @@ function testLRUExpiration(success) {
     assertEqual(cache.getItem("foo2"), "bar2");
 
     cache.setItem("foo3", "bar3");
-    assertEqual(cache.count_, 3);
+    assertEqual(cache.size(), 3);
 
     // Allow time for cache to be purged
     setTimeout(function() {
       assertEqual(cache.getItem("foo1"), null);
       assertEqual(cache.getItem("foo2"), "bar2");
       assertEqual(cache.getItem("foo3"), "bar3");
-      assertEqual(cache.count_, 2);
+      assertEqual(cache.size(), 2);
       success();
     }, TIMEOUT)
   }, TIMEOUT)
@@ -98,14 +100,14 @@ function testPriorityExpiration(success) {
 
     setTimeout(function() {
       cache.setItem("foo3", "bar3");
-      assertEqual(cache.count_, 3);
+      assertEqual(cache.size(), 3);
 
       // Allow time for cache to be purged
       setTimeout(function() {
         assertEqual(cache.getItem("foo1"), "bar1");
         assertEqual(cache.getItem("foo2"), null);
         assertEqual(cache.getItem("foo3"), "bar3");
-        assertEqual(cache.count_, 2);
+        assertEqual(cache.size(), 2);
         success();
       }, TIMEOUT)
     }, TIMEOUT)
@@ -140,12 +142,12 @@ function testFillFactor(success) {
   for (var i = 1; i <= 100; i++) {
     cache.setItem("foo" + i, "bar" + i);
   }
-  assertEqual(cache.count_, 100);
+  assertEqual(cache.size(), 100);
   setTimeout(function() {
-    assertEqual(cache.count_, 100);
+    assertEqual(cache.size(), 100);
     cache.setItem("purge", "do it");
     setTimeout(function() {
-      assertEqual(cache.count_, 75);
+      assertEqual(cache.size(), 75);
       success();
     }, TIMEOUT)
   }, TIMEOUT)
@@ -161,25 +163,38 @@ function testLocalStorageCache(success) {
   assertEqual(stats.hits, 1);
   assertEqual(stats.misses, 1);
   assertEqual(cache.toHtmlString(), "1 item(s) in cache<br /><ul><li>foo1 = bar1</li></ul>");
-  assertEqual(cache.count_, 1);
+  assertEqual(cache.size(), 1);
   assertEqual(localStorage.length, 1);
 
   setTimeout(function() {
     cache.setItem("foo2", "bar2");
     cache.setItem("foo3", "bar3");
     setTimeout(function() {
-      assertEqual(cache.count_, 2);
+      assertEqual(cache.size(), 2);
       assertEqual(localStorage.length, 2);
 
       cache.clear();
       assertEqual(cache.getItem("foo1"), null);
       assertEqual(cache.getItem("foo2"), null);
       assertEqual(cache.getItem("foo3"), null);
-      assertEqual(cache.count_, 0);
+      assertEqual(cache.size(), 0);
       assertEqual(localStorage.length, 0);
       success();
     }, TIMEOUT)
   }, TIMEOUT)
+}
+
+function testLocalStorageExisting(success) {
+  localStorage.clear();
+  var cache = new Cache(-1, false, new Cache.LocalStorageCacheStorage());
+  cache.setItem("foo", "bar");
+  var cache2 = new Cache(-1, false, new Cache.LocalStorageCacheStorage());
+  assertEqual(cache.size(), 1);
+  assertEqual(cache2.size(), 1);
+  cache.removeItem("foo");
+  assertEqual(cache.size(), 0);
+  assertEqual(cache2.size(), 0);
+  success();
 }
 
 function testLocalStorageCacheMaxSize(success) {
@@ -202,7 +217,6 @@ function testLocalStorageCacheMaxSize(success) {
   }
 }
 
-
 function runTests(tests) {
   if (tests.length === 0) return console.log("All tests passed!");
   var next = tests.shift();
@@ -221,5 +235,6 @@ runTests([
   testResize,
   testFillFactor,
   testLocalStorageCache,
+  testLocalStorageExisting,
   testLocalStorageCacheMaxSize
 ]);


### PR DESCRIPTION
- LocalStorage now works correctly when it created from both and empty and pre-populated localStorage
- Allow multiple localStorage-backed cache's with the same namespace to work together on one page
- Removing an item that doesn't exist now doesn't throw an exception
- Added removeItem and size public methods
- Updated tests and docs.
